### PR TITLE
Fix version in launch scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![logo](doc/dispatcher-services-logo.png)
 
-[![Github](https://img.shields.io/badge/github-1.4.7-green?style=flat&logo=github)](https://github.com/eipm/DispatcherSuite) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14975839.svg)](https://zenodo.org/doi/10.5281/zenodo.14975839)
+[![Github](https://img.shields.io/badge/github-1.4.8-green?style=flat&logo=github)](https://github.com/eipm/DispatcherSuite) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.14975839.svg)](https://zenodo.org/doi/10.5281/zenodo.14975839)
 
 A set of microservices to interface with different messaging systems.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,9 @@ Use this section to tell people about which versions of your project are
 currently being supported with security updates.
 
 | Version | Supported          |
-| ------- | ------------------ |
-| 1.4.7   | :white_check_mark: |
-| < 1.4.7   | :x:                |
+|---------| ------------------ |
+| 1.4.8   | :white_check_mark: |
+| < 1.4.8 | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/kafka-service/runApp.sh
+++ b/kafka-service/runApp.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-java -jar target/kafka-service-1.4.6.war -Dspring.config.location=/path/to/EIPM/DispatcherSuite/kafka-service/application.yml
+java -jar target/kafka-service-1.4.8.war -Dspring.config.location=/path/to/EIPM/DispatcherSuite/kafka-service/application.yml

--- a/kafka-service/runContainer.sh
+++ b/kafka-service/runContainer.sh
@@ -10,4 +10,4 @@ WORKING_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
  -v /path/to/tmp/:/tmp \
  -v /path/to/DispatcherSuite/kafka-service/log/:/log \
  -v "${WORKING_DIR}/application.yml":/application.yml \
-  eipm/kafka-dispatcher:1.4.6
+  eipm/kafka-dispatcher:1.4.8

--- a/kafka-service/runSSLContainer.sh
+++ b/kafka-service/runSSLContainer.sh
@@ -7,5 +7,5 @@ docker run -p 8443:8443 --rm  \
  -e HOST_USER=$LOGNAME \
  -v "${WORKING_DIR}/application-ssl.yml":/application.yml \
   -v /path/to//DispatcherSuite/kafka-service/scripts/kd-keystore.jks:/kd-keystore.jks \
-  eipm/kafka-dispatcher:1.4.6
+  eipm/kafka-dispatcher:1.4.8
 


### PR DESCRIPTION
This pull request updates the DispatcherSuite project to version 1.4.8, reflecting changes in documentation, scripts, and container configurations to ensure consistency with the new version. The most important changes involve version updates across various files.

### Version Updates:

* **Documentation Updates:**
  - Updated version badge in `README.md` to reflect the new version 1.4.8.
  - Updated `SECURITY.md` to indicate that version 1.4.8 is supported with security updates, while earlier versions are no longer supported.

* **Script Updates:**
  - Updated the `runApp.sh` script to use `kafka-service-1.4.8.war` instead of `kafka-service-1.4.6.war`.

* **Container Configuration Updates:**
  - Updated the `runContainer.sh` script to use the `eipm/kafka-dispatcher:1.4.8` Docker image.
  - Updated the `runSSLContainer.sh` script to use the `eipm/kafka-dispatcher:1.4.8` Docker image.