### PR TITLE
Configure dependabot to target develop.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Scanning the Maven dependencies and creating pull requests to update them.
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/" # Location of pom.xml ("/" = repo root)
+    schedule:
+      interval: "daily"
+    target-branch: "develop" # PRs go to develop branch


### PR DESCRIPTION
This pull request sets up automated dependency updates for Maven projects using Dependabot. The configuration ensures that Maven dependencies are scanned daily and that update pull requests are created targeting the `develop` branch.

Dependabot configuration:

* Added a `.github/dependabot.yml` file to enable daily scanning and updating of Maven dependencies, with pull requests directed to the `develop` branch.