### PR TITLE
Switch to Java 21.

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="corretto-18" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="temurin-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -7,8 +7,8 @@
     <option name="autoReloadType" value="ALL" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="dae2f7e8-1246-45f6-adfc-bd5a285a7c0b" name="Default Changelist" comment="Advance parent and service version.">
-      <change beforePath="$PROJECT_DIR$/pom.xml" beforeDir="false" afterPath="$PROJECT_DIR$/pom.xml" afterDir="false" />
+    <list default="true" id="dae2f7e8-1246-45f6-adfc-bd5a285a7c0b" name="Default Changelist" comment="Configure dependabot to target develop.">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -230,11 +230,11 @@
     "Maven.dispatcher-suite [package].executor": "Run",
     "Maven.dispatcher-suite [spotless:apply].executor": "Run",
     "RunOnceActivity.git.unshallow": "true",
-    "git-widget-placeholder": "develop",
+    "git-widget-placeholder": "Enable-dependabot-dev-branch",
     "kotlin-language-version-configured": "true",
-    "project.structure.last.edited": "Modules",
+    "project.structure.last.edited": "Project",
     "project.structure.proportion": "0.0",
-    "project.structure.side.proportion": "0.0",
+    "project.structure.side.proportion": "0.2",
     "run.code.analysis.last.selected.profile": "pProject Default",
     "settings.editor.selected.configurable": "preferences.pluginManager"
   }
@@ -1111,8 +1111,8 @@
     <MESSAGE value="Add new sample configs." />
     <MESSAGE value="Advance Spring Boot to 3.5.0." />
     <MESSAGE value="Advance parent and service version." />
-    <MESSAGE value="Address some security vulnerabilities." />
-    <option name="LAST_COMMIT_MESSAGE" value="Address some security vulnerabilities." />
+    <MESSAGE value="Configure dependabot to target develop." />
+    <option name="LAST_COMMIT_MESSAGE" value="Configure dependabot to target develop." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/executors/pom.xml
+++ b/executors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dispatcher-suite</artifactId>
         <groupId>edu.cornell.eipm.messaging.microservices</groupId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>executors</artifactId>

--- a/kafka-service/pom.xml
+++ b/kafka-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dispatcher-suite</artifactId>
         <groupId>edu.cornell.eipm.messaging.microservices</groupId>
-        <version>1.4.2-SNAPSHOT</version>
+        <version>1.4.3-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,12 @@
     <groupId>edu.cornell.eipm.messaging.microservices</groupId>
     <artifactId>dispatcher-suite</artifactId>
     <name>Dispatcher Suite</name>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Dispatcher Services Suite</description>
 
     <properties>
-        <java.version>18</java.version>
+        <java.version>21</java.version>
         <spotless.version>2.46.1</spotless.version>
     </properties>
 


### PR DESCRIPTION
This pull request updates the project to use Java 21 and advances the parent and service versions to `1.4.3-SNAPSHOT`. It also includes some minor changes to IDE configuration files to reflect these updates and a new changelist comment regarding dependabot configuration.

**Build and language updates:**

* Updated the Java version from 18 to 21 in both the main `pom.xml` and the IDE project configuration (`.idea/misc.xml`). [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L19-R24) [[2]](diffhunk://#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229L11-R11)
* Advanced the parent and service versions from `1.4.2-SNAPSHOT` to `1.4.3-SNAPSHOT` in `pom.xml`, `executors/pom.xml`, and `kafka-service/pom.xml`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L19-R24) [[2]](diffhunk://#diff-348e161092089d06e1b40c11f8c534f5dedf2f35e03828ee3cbe6a6f5768b1e8L8-R8) [[3]](diffhunk://#diff-b84dec00fe0d876830b887142c71ee8910a0cabc94091c1936308e37ba2a8fdaL8-R8)

**IDE configuration and changelist updates:**

* Changed the changelist comment in `.idea/workspace.xml` to "Configure dependabot to target develop" and updated the last commit message to match. [[1]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL10-R11) [[2]](diffhunk://#diff-9f043e4e89d784b579b6d75ea8704b232f9475fa5b3afd11f805fdf8e74c675cL1114-R1115)
* Updated workspace settings in `.idea/workspace.xml`, including branch placeholder and project structure proportions.