### PR TITLE
Advance-parent-version

### DIFF
--- a/executors/pom.xml
+++ b/executors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dispatcher-suite</artifactId>
         <groupId>edu.cornell.eipm.messaging.microservices</groupId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>executors</artifactId>

--- a/kafka-service/pom.xml
+++ b/kafka-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>dispatcher-suite</artifactId>
         <groupId>edu.cornell.eipm.messaging.microservices</groupId>
-        <version>1.4.3-SNAPSHOT</version>
+        <version>1.4.4-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <groupId>edu.cornell.eipm.messaging.microservices</groupId>
     <artifactId>dispatcher-suite</artifactId>
     <name>Dispatcher Suite</name>
-    <version>1.4.3-SNAPSHOT</version>
+    <version>1.4.4-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>Dispatcher Services Suite</description>
 


### PR DESCRIPTION
This pull request updates the project version from `1.4.3-SNAPSHOT` to `1.4.4-SNAPSHOT` across all relevant Maven configuration files. This ensures consistency in versioning for the parent project and its modules.

Version updates:

* Updated the parent project version in `pom.xml` to `1.4.4-SNAPSHOT`.
* Updated the parent version reference in `executors/pom.xml` to `1.4.4-SNAPSHOT`.
* Updated the parent version reference in `kafka-service/pom.xml` to `1.4.4-SNAPSHOT`.